### PR TITLE
Add list messages using paging technique with cursor

### DIFF
--- a/common/utils/paging.go
+++ b/common/utils/paging.go
@@ -2,8 +2,8 @@ package utils
 
 
 type Paging struct {
-	Page  int `json:"page"`
-	Limit int `json:"limit"`
+	Page  int `json:"page" form:"page"`
+	Limit int `json:"limit" form:"limit"`
 	Total int64 `json:"total"`
 	FakeCursor string `json:"cursor" form:"cursor"`
 	NextCursor string `json:"next_cursor"`

--- a/module/message/business/list_message.go
+++ b/module/message/business/list_message.go
@@ -1,0 +1,24 @@
+package business
+
+import (
+	"context"
+
+	"github.com/hoangminhphuc/goph-chat/common/utils"
+	"github.com/hoangminhphuc/goph-chat/module/message/model"
+)
+
+type ListMessageRepo interface {
+	ListMessage(ctx context.Context, roomID int, paging *utils.Paging) ([]model.Message, error)
+}
+
+type ListMessageBusiness struct {
+	repo ListMessageRepo
+}
+
+func NewListMessageBusiness(repo ListMessageRepo) *ListMessageBusiness {
+	return &ListMessageBusiness{repo: repo}
+}
+
+func (b *ListMessageBusiness) ListMessage(ctx context.Context, roomID int, paging *utils.Paging) ([]model.Message, error) {
+	return b.repo.ListMessage(ctx, roomID, paging)
+}

--- a/module/message/repository/list.go
+++ b/module/message/repository/list.go
@@ -1,0 +1,41 @@
+package repository
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hoangminhphuc/goph-chat/common"
+	"github.com/hoangminhphuc/goph-chat/common/utils"
+	"github.com/hoangminhphuc/goph-chat/module/message/model"
+)
+
+func (s *sqlRepo) ListMessage(ctx context.Context, roomID int, paging *utils.Paging) ([]model.Message, error) {
+	db := s.db.Table(model.Message{}.TableName()).Where("room_id = ?", roomID)
+
+	if err := db.Select("id").Count(&paging.Total).Error; err != nil {
+		return nil, common.WrapError(err, "cannot count total messages", http.StatusBadRequest)
+	}
+
+	if paging.FakeCursor != "" {
+		uuid, err := utils.DecodeID(paging.FakeCursor)
+		if err != nil {
+			return nil, common.WrapError(err, "invalid cursor", http.StatusBadRequest)
+		}
+		db = db.Where("id < ?", uuid)
+	} else {
+		db = db.Offset((paging.Page - 1) * paging.Limit)
+	}
+
+	var messages []model.Message
+
+	if err := db.Select("*").Order("id desc").Limit(paging.Limit).Find(&messages).Error; err != nil {
+		return nil, common.WrapError(err, "cannot find messages", http.StatusBadRequest)
+	}
+
+	if len(messages) > 0 {
+		messages[len(messages)-1].Mask()
+		paging.NextCursor = messages[len(messages)-1].FakeID
+	}
+
+	return messages, nil
+}

--- a/module/message/routes/routes.go
+++ b/module/message/routes/routes.go
@@ -8,6 +8,7 @@ import (
 
 func RegisterMessageRoute(message *gin.RouterGroup, serviceCtx serviceHub.ServiceHub) {
 
-	message.GET("/:id", rest.GetRecentMessages(serviceCtx))
+	message.GET("/:id/recent", rest.GetRecentMessages(serviceCtx))
 	message.PATCH("/:id", rest.EditMessage(serviceCtx))
+	message.GET("/:id", rest.ListMessage(serviceCtx))
 }

--- a/module/message/transport/rest/list_message_handler.go
+++ b/module/message/transport/rest/list_message_handler.go
@@ -1,0 +1,49 @@
+package rest
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	serviceHub "github.com/hoangminhphuc/goph-chat/boot"
+	"github.com/hoangminhphuc/goph-chat/common"
+	"github.com/hoangminhphuc/goph-chat/common/utils"
+	"github.com/hoangminhphuc/goph-chat/module/message/business"
+	"github.com/hoangminhphuc/goph-chat/module/message/repository"
+	"gorm.io/gorm"
+)
+
+func ListMessage(serviceCtx serviceHub.ServiceHub) func(*gin.Context) {
+	return func(c *gin.Context) {
+		db := serviceCtx.MustGetService(common.PluginDBMain).(*gorm.DB)
+
+		roomID, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			common.ErrorResponse(c, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		var paging utils.Paging
+		if err := c.ShouldBindQuery(&paging); err != nil {
+			common.ErrorResponse(c, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		paging.Process()
+
+		repo := repository.NewSQLRepo(db)
+		business := business.NewListMessageBusiness(repo)
+
+		messages, err := business.ListMessage(c.Request.Context(), roomID, &paging)
+		if err != nil {
+			common.ErrorResponse(c, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		for i := range messages {
+			messages[i].Mask()
+		}
+
+		common.SuccessResponse(c, "Messages retrieved successfully", "paging", paging, "messages", messages)
+	}
+}


### PR DESCRIPTION
## List Messages API

This API is used to retrieve older messages beyond the most recent 100.

### Usage Flow:
1. When a user opens a group chat, the client first calls **`GetRecentMessages`** to fetch the latest 100 messages from a Redis list.
2. If the user scrolls up past those 100 messages, the client then calls **`ListMessages`** with a cursor to fetch older messages from the database.

### Key Difference:
- **`GetRecentMessages`** is fast and reads from Redis (latest 100 only).
- **`ListMessages`** uses cursor-based pagination and reads from persistent storage for full message history.
